### PR TITLE
WIP: Add Dunkl-Xu orthogonal polynomials on the unit disk

### DIFF
--- a/src/MultivariateOrthogonalPolynomials.jl
+++ b/src/MultivariateOrthogonalPolynomials.jl
@@ -20,14 +20,14 @@ import InfiniteArrays: InfiniteCardinal
 
 import ClassicalOrthogonalPolynomials: jacobimatrix, Weighted, orthogonalityweight, HalfWeighted
 import HarmonicOrthogonalPolynomials: BivariateOrthogonalPolynomial, MultivariateOrthogonalPolynomial, Plan,
-                                          PartialDerivative, BlockOneTo, BlockRange1, interlace
+                                          PartialDerivative, AngularMomentum, BlockOneTo, BlockRange1, interlace
 
 export MultivariateOrthogonalPolynomial, BivariateOrthogonalPolynomial,
        UnitTriangle, UnitDisk,
        JacobiTriangle, TriangleWeight, WeightedTriangle,
        DunklXuDisk, DunklXuDiskWeight, WeightedDunklXuDisk,
        Zernike, ZernikeWeight, zerniker, zernikez,
-       PartialDerivative, Laplacian, AbsLaplacianPower,
+       PartialDerivative, Laplacian, AbsLaplacianPower, AngularMomentum,
        RadialCoordinate, Weighted, Block
 
 include("ModalInterlace.jl")

--- a/src/MultivariateOrthogonalPolynomials.jl
+++ b/src/MultivariateOrthogonalPolynomials.jl
@@ -1,6 +1,6 @@
 module MultivariateOrthogonalPolynomials
-using ClassicalOrthogonalPolynomials, FastTransforms, BlockBandedMatrices, BlockArrays, DomainSets, 
-      QuasiArrays, StaticArrays, ContinuumArrays, InfiniteArrays, InfiniteLinearAlgebra, 
+using ClassicalOrthogonalPolynomials, FastTransforms, BlockBandedMatrices, BlockArrays, DomainSets,
+      QuasiArrays, StaticArrays, ContinuumArrays, InfiniteArrays, InfiniteLinearAlgebra,
       LazyArrays, SpecialFunctions, LinearAlgebra, BandedMatrices, LazyBandedMatrices, ArrayLayouts,
       HarmonicOrthogonalPolynomials
 
@@ -22,12 +22,17 @@ import ClassicalOrthogonalPolynomials: jacobimatrix, Weighted, orthogonalityweig
 import HarmonicOrthogonalPolynomials: BivariateOrthogonalPolynomial, MultivariateOrthogonalPolynomial, Plan,
                                           PartialDerivative, BlockOneTo, BlockRange1, interlace
 
-export UnitTriangle, UnitDisk, JacobiTriangle, TriangleWeight, WeightedTriangle, PartialDerivative, Laplacian, 
-      MultivariateOrthogonalPolynomial, BivariateOrthogonalPolynomial, Zernike, RadialCoordinate,
-      zerniker, zernikez, Weighted, Block, ZernikeWeight, AbsLaplacianPower
+export MultivariateOrthogonalPolynomial, BivariateOrthogonalPolynomial,
+       UnitTriangle, UnitDisk,
+       JacobiTriangle, TriangleWeight, WeightedTriangle,
+       DunklXuDisk, DunklXuDiskWeight, WeightedDunklXuDisk,
+       Zernike, ZernikeWeight, zerniker, zernikez,
+       PartialDerivative, Laplacian, AbsLaplacianPower,
+       RadialCoordinate, Weighted, Block
 
 include("ModalInterlace.jl")
 include("disk.jl")
+include("rectdisk.jl")
 include("triangle.jl")
 
 

--- a/src/rectdisk.jl
+++ b/src/rectdisk.jl
@@ -57,6 +57,28 @@ end
     DunklXuDisk(β+1) * _BandedBlockBandedMatrix(((k .+ T(2β)) ./ 2)', axes(k,1), (-1,1), (-1,1))
 end
 
+@simplify function *(Dx::PartialDerivative{1}, w_P::WeightedDunklXuDisk)
+    wP, P = w_P.args
+    @assert P.β == wP.β
+    β = P.β
+    n = mortar(Fill.(oneto(∞),oneto(∞)))
+    k = mortar(Base.OneTo.(oneto(∞)))
+    dat = BlockBroadcastArray(hcat,
+        (-4 .* (k .+ (β - 1)).*(n .- k .+ 1)./(2k .+ (2β - 1))),
+        0 .* n,
+        (-k .* (k .+ 1) ./ ((2k .+ (2β - 1)) .* (k .+ β)) .* (n .+ k .+ 2β))
+        )
+    WeightedDunklXuDisk(β-1) * _BandedBlockBandedMatrix(dat', axes(k,1), (1,-1), (2,0))
+end
+
+@simplify function *(Dy::PartialDerivative{2}, w_P::WeightedDunklXuDisk)
+    wP, P = w_P.args
+    @assert P.β == wP.β
+    k = mortar(Base.OneTo.(oneto(∞)))
+    T = promote_type(eltype(Dy), eltype(P)) # avoid bug in convert
+    WeightedDunklXuDisk(P.β-1) * _BandedBlockBandedMatrix((T(-2).*k)', axes(k,1), (1,-1), (1,-1))
+end
+
 # P^{(β)} ↗ P^{(β+1)}
 function dunklxu_raising(β)
     n = mortar(Fill.(oneto(∞),oneto(∞)))

--- a/src/rectdisk.jl
+++ b/src/rectdisk.jl
@@ -1,0 +1,155 @@
+"""
+    DunklXuDisk(β)
+
+are the orthogonal polynomials on the unit disk with respect to (1-x^2-y^2)^β, defined as `P_{n-k}^{k+β+1/2,k+β+1/2}(x)*(1-x^2)^{k/2}*P_k^{β,β}(y/sqrt{1-x^2})`.
+"""
+struct DunklXuDisk{T, V} <: BivariateOrthogonalPolynomial{T}
+    β::V
+end
+
+DunklXuDisk(β::T) where T = DunklXuDisk{float(T), T}(β)
+DunklXuDisk() = DunklXuDisk(0)
+
+==(D1::DunklXuDisk, D2::DunklXuDisk) = D1.β == D2.β
+
+axes(P::DunklXuDisk{T}) where T = (Inclusion(UnitDisk{T}()),blockedrange(oneto(∞)))
+
+copy(A::DunklXuDisk) = A
+
+Base.summary(io::IO, P::DunklXuDisk) = print(io, "DunklXuDisk($(P.β))")
+
+
+"""
+    DunklXuDiskWeight(β)
+
+is a quasi-vector representing `(1-x^2-y^2)^β`.
+"""
+struct DunklXuDiskWeight{T, V} <: Weight{T}
+    β::V
+end
+
+DunklXuDiskWeight(β::T) where T = DunklXuDiskWeight{float(T),T}(β)
+
+axes(P::DunklXuDiskWeight{T}) where T = (Inclusion(UnitDisk{T}()),)
+
+Base.summary(io::IO, P::DunklXuDiskWeight) = print(io, "(1-x^2-y^2)^$(P.β) on the unit disk")
+
+const WeightedDunklXuDisk{T} = WeightedBasis{T,<:DunklXuDiskWeight,<:DunklXuDisk}
+
+WeightedDunklXuDisk(β) = DunklXuDiskWeight(β) .* DunklXuDisk(β)
+
+@simplify function *(Dx::PartialDerivative{1}, P::DunklXuDisk)
+    β = P.β
+    n = mortar(Fill.(oneto(∞),oneto(∞)))
+    k = mortar(Base.OneTo.(oneto(∞)))
+    dat = BlockBroadcastArray(hcat,
+        ((k .+ (β - 1)) ./ (2k .+ (2β - 1)) .* (n .- k .+ 1)),
+        0 .* n,
+        (((k .+ 2β) .* (k .+ (2β + 1))) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β)) .* (n .+ k .+ 2β) ./ 2)
+        )
+    DunklXuDisk(β+1) * _BandedBlockBandedMatrix(dat', axes(k,1), (-1,1), (0,2))
+end
+
+@simplify function *(Dy::PartialDerivative{2}, P::DunklXuDisk)
+    β = P.β
+    k = mortar(Base.OneTo.(oneto(∞)))
+    T = promote_type(eltype(Dy), eltype(P)) # avoid bug in convert
+    DunklXuDisk(β+1) * _BandedBlockBandedMatrix(((k .+ T(2β)) ./ 2)', axes(k,1), (-1,1), (-1,1))
+end
+
+# P^{(β)} ↗ P^{(β+1)}
+function dunklxu_raising(β)
+    n = mortar(Fill.(oneto(∞),oneto(∞)))
+    k = mortar(Base.OneTo.(oneto(∞)))
+    dat = PseudoBlockArray(Vcat(
+        (-(k .+ (β - 1)) .* (2n .+ (2β - 1)) ./ ((2k .+ (2β - 1)) .* (4n .+ 4β)))', # n-2, k-2
+        (0 .* n)', # n-2, k-1
+        (-(k .+ 2β) .* (k .+ (2β + 1)) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β)) .* (2n .+ (2β-1)) ./ (8n .+ 8β))', # n-2, k
+        (0 .* n)', # n-1, k-2
+        (0 .* n)', # n-1, k-1
+        (0 .* n)', # n-1, k
+        (2 .* (k .+ (β - 1)) .* (n .- k .+ 1) .* (n .- k .+ 2) ./ ((2k .+ (2β-1)) .* (2n .+ 2β) .* (2n .+ (2β + 1))))', # n, k-2
+        (0 .* n)', # n, k-1
+        ((k .+ 2β) .* (k .+ (2β + 1)) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β)) .* (n .+ k .+ 2β) .* (n .+ k .+ (2β + 1)) ./ ((2n .+ 2β) .* (2n .+ (2β + 1))))' # n, k
+        ), (blockedrange(Fill(3,3)), axes(n,1)))
+    _BandedBlockBandedMatrix(dat, axes(k,1), (0,2), (0,2))
+end
+
+function \(A::DunklXuDisk, B::DunklXuDisk)
+    if A.β == B.β
+        Eye((axes(B,2),))
+    elseif A.β == B.β + 1
+        dunklxu_raising(B.β)
+    else
+        error("not implemented for $A and $B")
+    end
+end
+
+# (1-x^2-y^2) P^{(β)} ↘ P^{(β-1)}
+function dunklxu_lowering(β)
+    n = mortar(Fill.(oneto(∞),oneto(∞)))
+    k = mortar(Base.OneTo.(oneto(∞)))
+    dat = PseudoBlockArray(Vcat(
+        ((2n .+ (2β - 1)) ./ (n .+ β) .* (k .+ (β - 1)) ./ (2k .+ (2β - 1)))', # n, k
+        (0 .* n)', # n, k+1
+        ((n .+ (β - 1/2)) ./ (n .+ β) .* k .* (k .+ 1) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β)))', # n, k+2
+        (0 .* n)', # n+1, k
+        (0 .* n)', # n+1, k+1
+        (0 .* n)', # n+1, k+2
+        (-8 .* (n .- k .+ 1) .* (n .- k .+ 2) ./ ((2n .+ 2β) .* (2n .+ (2β + 1))) .* (k .+ (β - 1)) ./(2k .+ (2β - 1)))', # n+2, k
+        (0 .* n)', # n+2, k+1
+        (-4 .* (n .+ k .+ 2β) .* (n .+ k .+ (2β + 1)) ./ ((2n .+ 2β) .* (2n .+ (2β + 1))) .* k .* (k .+ 1) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β)))' # n+2, k+2
+        ), (blockedrange(Fill(3,3)), axes(n,1)))
+    _BandedBlockBandedMatrix(dat, axes(k,1), (2,0), (2,0))
+end
+
+function \(w_A::WeightedDunklXuDisk, w_B::WeightedDunklXuDisk)
+    wA,A = w_A.args
+    wB,B = w_B.args
+
+    @assert wA.β == A.β
+    @assert wB.β == B.β
+
+    if A.β == B.β
+        Eye((axes(B,2),))
+    elseif A.β + 1 == B.β
+        dunklxu_lowering(B.β)
+    else
+        error("not implemented for $A and $B")
+    end
+end
+
+\(w_A::DunklXuDisk, w_B::WeightedDunklXuDisk) =
+    (DunklXuDiskWeight(0) .* w_A) \ w_B
+
+# Actually Jxᵀ
+function jacobimatrix(::Val{1}, P::DunklXuDisk)
+    β = P.β
+    n = mortar(Fill.(oneto(∞),oneto(∞)))
+    k = mortar(Base.OneTo.(oneto(∞)))
+    dat = PseudoBlockArray(Vcat(
+        ((2n .+ (2β - 1)) ./ (4n .+ 4β))', # n-1, k
+        (0 .* n)', # n, k
+        ((n .- k .+ 1) .* (n .+ k .+ 2β) ./ ((n .+ β) .* (2n .+ (2β + 1))))', # n+1, k
+        ), (blockedrange(Fill(1, 3)), axes(n,1)))
+    _BandedBlockBandedMatrix(dat, axes(k,1), (1,1), (0,0))
+end
+
+# Actually Jyᵀ
+function jacobimatrix(::Val{2}, P::DunklXuDisk)
+    β = P.β
+    n = mortar(Fill.(oneto(∞),oneto(∞)))
+    k = mortar(Base.OneTo.(oneto(∞)))
+    dat = PseudoBlockArray(Vcat(
+        ((k .+ (β - 1)) .* (2n .+ (2β - 1)) ./ ((2k .+ (2β - 1)) .* (2n .+ 2β)))', # n-1, k-1
+        (0 .* n)', # n-1, k
+        (-k .* (k .+ 2β) .* (2n .+ (2β - 1)) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β) .* (4n .+ 4β)))', # n-1, k+1
+        (0 .* n)', # n, k-1
+        (0 .* n)', # n, k
+        (0 .* n)', # n, k+1
+        (-(2k .+ (2β - 2)) .* (n .- k .+ 1) .* (n .- k .+ 2) ./ ((2k .+ (2β - 1)) .* (n .+ β) .* (2n .+ (2β + 1))))', # n+1, k-1
+        (0 .* n)', # n+1, k
+        (k .* (k .+ 2β) .* (n .+ k .+ 2β) .* (n .+ k .+ (2β + 1)) ./ ((2k .+ (2β - 1)) .* (2k .+ 2β) .* (n .+ β) .* (2n .+ (2β + 1))))', # n+1, k+1
+        ), (blockedrange(Fill(3, 3)), axes(n,1)))
+    _BandedBlockBandedMatrix(dat, axes(k,1), (1,1), (1,1))
+end

--- a/src/rectdisk.jl
+++ b/src/rectdisk.jl
@@ -176,29 +176,6 @@ function jacobimatrix(::Val{2}, P::DunklXuDisk)
     _BandedBlockBandedMatrix(dat, axes(k,1), (1,1), (1,1))
 end
 
-
-
-#########
-# AngularMomentum
-# Applies the partial derivative with respect to the last angular variable in the coordinate system.
-# For example, in polar coordinates (r, θ) in ℝ² or cylindrical coordinates (r, θ, z) in ℝ³, we apply ∂ / ∂θ = (x ∂ / ∂y - y ∂ / ∂x).
-# In spherical coordinates (ρ, θ, φ) in ℝ³, we apply ∂ / ∂φ = (x ∂ / ∂y - y ∂ / ∂x).
-#########
-
-struct AngularMomentum{T,Ax<:Inclusion} <: LazyQuasiMatrix{T}
-    axis::Ax
-end
-
-AngularMomentum{T}(axis::Inclusion) where T = AngularMomentum{T,typeof(axis)}(axis)
-AngularMomentum{T}(domain) where T = AngularMomentum{T}(Inclusion(domain))
-AngularMomentum(axis) = AngularMomentum{eltype(eltype(axis))}(axis)
-
-axes(A::AngularMomentum) = (A.axis, A.axis)
-==(a::AngularMomentum, b::AngularMomentum) = a.axis == b.axis
-copy(A::AngularMomentum) = AngularMomentum(copy(A.axis))
-
-^(A::AngularMomentum, k::Integer) = ApplyQuasiArray(^, A, k)
-
 @simplify function *(A::AngularMomentum, P::DunklXuDisk)
     β = P.β
     n = mortar(Fill.(oneto(∞),oneto(∞)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,6 @@ using MultivariateOrthogonalPolynomials, Test
 
 include("test_modalinterlace.jl")
 include("test_disk.jl")
+include("test_rectdisk.jl")
 include("test_triangle.jl")
 # include("test_dirichlettriangle.jl")

--- a/test/test_rectdisk.jl
+++ b/test/test_rectdisk.jl
@@ -6,6 +6,7 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
     @testset "basics" begin
         P = DunklXuDisk()
         @test copy(P) ≡ P
+        @test P ≠ DunklXuDisk(0.123)
 
         xy = axes(P,1)
         x,y = first.(xy),last.(xy)
@@ -32,7 +33,7 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
         X = P \ (x .* P)
         Y = P \ (y .* P)
 
-        @test (L*R)[Block.(1:N), Block.(1:N)] ≈ (I - X^2 - Y^2)[Block.(1:N), Block.(1:N)]
+        @test (L * R)[Block.(1:N), Block.(1:N)] ≈ (I - X^2 - Y^2)[Block.(1:N), Block.(1:N)]
 
         ∂x = PartialDerivative{1}(axes(P, 1))
         ∂y = PartialDerivative{2}(axes(P, 1))
@@ -43,7 +44,7 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
         Mx = Q \ (x .* Q)
         My = Q \ (y .* Q)
 
-        A = Mx[Block.(1:N), Block.(1:N+1)]*Dy[Block.(1:N+1), Block.(1:N)] - My[Block.(1:N), Block.(1:N+1)]*Dx[Block.(1:N+1), Block.(1:N)]
+        A = (Mx * Dy - My * Dx)[Block.(1:N), Block.(1:N)]
 
         B = (Q \ P)[Block.(1:N), Block.(1:N)]
 
@@ -55,11 +56,15 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
 
         @test λ ≈ im*imag(λ)
 
-        ∂θ = AngularMomentum(P)
+        ∂θ = AngularMomentum(axes(P, 1))
+        @test axes(∂θ) == (axes(P, 1), axes(P, 1))
+        @test ∂θ == AngularMomentum(axes(Q, 1))
+        @test copy(∂θ) ≡ ∂θ
 
         A = P \ (∂θ * P)
 
         @test A[Block.(1:N), Block.(1:N)] ≈ C
+        @test (A^2)[Block.(1:N), Block.(1:N)] ≈ A[Block.(1:N), Block.(1:N)]^2
 
         ∂x = PartialDerivative{1}(axes(WQ, 1))
         ∂y = PartialDerivative{2}(axes(WQ, 1))

--- a/test/test_rectdisk.jl
+++ b/test/test_rectdisk.jl
@@ -55,6 +55,12 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering
 
         @test λ ≈ im*imag(λ)
 
+        ∂θ = AngularMomentum(P)
+
+        A = P \ (∂θ * P)
+
+        @test A[Block.(1:N), Block.(1:N)] ≈ C
+
         @testset "truncations" begin
             KR,JR = Block.(1:N),Block.(1:N)
 

--- a/test/test_rectdisk.jl
+++ b/test/test_rectdisk.jl
@@ -1,6 +1,6 @@
 using MultivariateOrthogonalPolynomials, StaticArrays, BlockArrays, BlockBandedMatrices, ArrayLayouts,
         QuasiArrays, Test, ClassicalOrthogonalPolynomials, BandedMatrices, FastTransforms, LinearAlgebra
-import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering
+import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, AngularMomentum
 
 @testset "Dunkl-Xu disk" begin
     @testset "basics" begin
@@ -34,8 +34,8 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering
 
         @test (L*R)[Block.(1:N), Block.(1:N)] ≈ (I - X^2 - Y^2)[Block.(1:N), Block.(1:N)]
 
-        ∂x = PartialDerivative{1}(P)
-        ∂y = PartialDerivative{2}(P)
+        ∂x = PartialDerivative{1}(axes(P, 1))
+        ∂y = PartialDerivative{2}(axes(P, 1))
 
         Dx = Q \ (∂x * P)
         Dy = Q \ (∂y * P)
@@ -60,6 +60,12 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering
         A = P \ (∂θ * P)
 
         @test A[Block.(1:N), Block.(1:N)] ≈ C
+
+        ∂x = PartialDerivative{1}(axes(WQ, 1))
+        ∂y = PartialDerivative{2}(axes(WQ, 1))
+
+        wDx = WP \ (∂x * WQ)
+        wDy = WP \ (∂y * WQ)
 
         @testset "truncations" begin
             KR,JR = Block.(1:N),Block.(1:N)

--- a/test/test_rectdisk.jl
+++ b/test/test_rectdisk.jl
@@ -59,15 +59,10 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
         @test λ ≈ im*imag(λ)
 
         ∂θ = AngularMomentum(axes(P, 1))
-        @test axes(∂θ) == (axes(P, 1), axes(P, 1))
-        @test ∂θ == AngularMomentum(axes(Q, 1)) == AngularMomentum(axes(P, 1).domain)
-        @test copy(∂θ) ≡ ∂θ
-
         A = P \ (∂θ * P)
+        A2 = P \ (∂θ^2 * P)
 
         @test A[Block.(1:N), Block.(1:N)] ≈ C
-
-        A2 = P \ (∂θ^2 * P)
         @test A2[Block.(1:N), Block.(1:N)] ≈ (A^2)[Block.(1:N), Block.(1:N)] ≈ A[Block.(1:N), Block.(1:N)]^2
 
         ∂x = PartialDerivative{1}(axes(WQ, 1))

--- a/test/test_rectdisk.jl
+++ b/test/test_rectdisk.jl
@@ -35,6 +35,8 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
 
         @test (L * R)[Block.(1:N), Block.(1:N)] ≈ (I - X^2 - Y^2)[Block.(1:N), Block.(1:N)]
 
+        @test (DunklXuDisk() \ WeightedDunklXuDisk(1.0))[Block.(1:N), Block.(1:N)] ≈ (WeightedDunklXuDisk(0.0) \ WeightedDunklXuDisk(1.0))[Block.(1:N), Block.(1:N)]
+
         ∂x = PartialDerivative{1}(axes(P, 1))
         ∂y = PartialDerivative{2}(axes(P, 1))
 
@@ -58,13 +60,15 @@ import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering, Ang
 
         ∂θ = AngularMomentum(axes(P, 1))
         @test axes(∂θ) == (axes(P, 1), axes(P, 1))
-        @test ∂θ == AngularMomentum(axes(Q, 1))
+        @test ∂θ == AngularMomentum(axes(Q, 1)) == AngularMomentum(axes(P, 1).domain)
         @test copy(∂θ) ≡ ∂θ
 
         A = P \ (∂θ * P)
 
         @test A[Block.(1:N), Block.(1:N)] ≈ C
-        @test (A^2)[Block.(1:N), Block.(1:N)] ≈ A[Block.(1:N), Block.(1:N)]^2
+
+        A2 = P \ (∂θ^2 * P)
+        @test A2[Block.(1:N), Block.(1:N)] ≈ (A^2)[Block.(1:N), Block.(1:N)] ≈ A[Block.(1:N), Block.(1:N)]^2
 
         ∂x = PartialDerivative{1}(axes(WQ, 1))
         ∂y = PartialDerivative{2}(axes(WQ, 1))

--- a/test/test_rectdisk.jl
+++ b/test/test_rectdisk.jl
@@ -1,0 +1,69 @@
+using MultivariateOrthogonalPolynomials, StaticArrays, BlockArrays, BlockBandedMatrices, ArrayLayouts,
+        QuasiArrays, Test, ClassicalOrthogonalPolynomials, BandedMatrices, FastTransforms, LinearAlgebra
+import MultivariateOrthogonalPolynomials: dunklxu_raising, dunklxu_lowering
+
+@testset "Dunkl-Xu disk" begin
+    @testset "basics" begin
+        P = DunklXuDisk()
+        @test copy(P) ≡ P
+
+        xy = axes(P,1)
+        x,y = first.(xy),last.(xy)
+        @test xy[SVector(0.1,0.2)] == SVector(0.1,0.2)
+        @test x[SVector(0.1,0.2)] == 0.1
+        @test y[SVector(0.1,0.2)] == 0.2
+    end
+
+    @testset "operators" begin
+        N = 5
+
+        β = 0.123
+
+        P = DunklXuDisk(β)
+        Q = DunklXuDisk(β+1)
+        WP = WeightedDunklXuDisk(β)
+        WQ = WeightedDunklXuDisk(β+1)
+
+        x, y = first.(axes(P, 1)), last.(axes(P, 1))
+
+        L = WP \ WQ
+        R = Q \ P
+
+        X = P \ (x .* P)
+        Y = P \ (y .* P)
+
+        @test (L*R)[Block.(1:N), Block.(1:N)] ≈ (I - X^2 - Y^2)[Block.(1:N), Block.(1:N)]
+
+        ∂x = PartialDerivative{1}(P)
+        ∂y = PartialDerivative{2}(P)
+
+        Dx = Q \ (∂x * P)
+        Dy = Q \ (∂y * P)
+
+        Mx = Q \ (x .* Q)
+        My = Q \ (y .* Q)
+
+        A = Mx[Block.(1:N), Block.(1:N+1)]*Dy[Block.(1:N+1), Block.(1:N)] - My[Block.(1:N), Block.(1:N+1)]*Dx[Block.(1:N+1), Block.(1:N)]
+
+        B = (Q \ P)[Block.(1:N), Block.(1:N)]
+
+        C = B \ A
+
+        @test C ≈ Tridiagonal(C)
+
+        λ = eigvals(Matrix(C))
+
+        @test λ ≈ im*imag(λ)
+
+        @testset "truncations" begin
+            KR,JR = Block.(1:N),Block.(1:N)
+
+            @test L[KR,JR] isa BandedBlockBandedMatrix
+            @test R[KR,JR] isa BandedBlockBandedMatrix
+            @test X[KR,JR] isa BandedBlockBandedMatrix
+            @test Y[KR,JR] isa BandedBlockBandedMatrix
+            @test Dx[KR,JR] isa BandedBlockBandedMatrix
+            @test Dy[KR,JR] isa BandedBlockBandedMatrix
+        end
+    end
+end


### PR DESCRIPTION
Just another set of OPs.

I'm using this to figure out the nontrivial discretization of the angular momentum operator on Dunkl-Xu polynomials as an infinite dimensional skew-symmetric block tridiagonal matrix. This leads to a fast solution to the Dunkl-Xu to Zernike connection problem.

It goes like this:
```julia
using MultivariateOrthogonalPolynomials, LinearAlgebra, Test
N = 5
β = 0.123

P = DunklXuDisk(β)
Q = DunklXuDisk(β+1)
x, y = first.(axes(P, 1)), last.(axes(P, 1))

∂x = PartialDerivative{1}(P)
∂y = PartialDerivative{2}(P)

Dx = Q \ (∂x * P)
Dy = Q \ (∂y * P)

Mx = Q \ (x .* Q)
My = Q \ (y .* Q)

A = Mx[Block.(1:N), Block.(1:N+1)]*Dy[Block.(1:N+1), Block.(1:N)] - My[Block.(1:N), Block.(1:N+1)]*Dx[Block.(1:N+1), Block.(1:N)]

B = (Q \ P)[Block.(1:N), Block.(1:N)]

C = B \ A

@test C ≈ Tridiagonal(C) # U wot, m8?

λ = eigvals(Matrix(C))

@test λ ≈ im*imag(λ)
```