### PR TITLE
Test that the examples in the examples folder run

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using MultivariateOrthogonalPolynomials, Test
 
-
 include("test_rect.jl")
 include("test_modalinterlace.jl")
 include("test_disk.jl")
 include("test_rectdisk.jl")
 include("test_triangle.jl")
 # include("test_dirichlettriangle.jl")
+include("test_examples.jl")

--- a/test/test_examples.jl
+++ b/test/test_examples.jl
@@ -1,0 +1,8 @@
+examples_path = joinpath(@__DIR__, "..", "examples")
+dir = readdir(examples_path)
+filter!(file -> endswith(file, ".jl"), dir)
+for example_path in dir
+    script = joinpath(examples_path, example_path)
+    mod = @eval module $(gensym()) end
+    Base.include(mod, script) # make sure each script is self-contained
+end


### PR DESCRIPTION
In response to #176, this PR adds an extra check that all the example scripts actually run by simply including them one at a time inside the tests. 

Currently, these tests will fail until #176 is fully addressed.